### PR TITLE
Changement pour coller à la route bookings/token

### DIFF
--- a/src/23_contremarques.apib.md
+++ b/src/23_contremarques.apib.md
@@ -1,25 +1,20 @@
-### Contremarques [/booking/]
+### Contremarques [/booking/token]
 
 Ceci décrit l'API utilisable par les partenaires techniques de Pass Culture qui souhaitent valider des contremarques.
 
-Les partenaires s'identifient auprès de l'API Pass Culture à l'aide d'un jeton disponible dans la section "structure" du portail pro.
-
 **Statut actuel : ébauche, pour discussions**
 
-##### Vérifier une contremarque [GET /bookings/<token>]
+##### Vérifier une contremarque [GET /bookings/token/\<token\>]
 
 Vérifie la validité d'une contremarque et récupère les informations de la transaction associée (uniquement si la contremarque est associée à une offre du partenaire identifié sur l'API).
 
 + Parameters
 
   + token (string) - le code de réservation
-  + email (optional, string) - correspond à l'email de la personne qui tente d'utiliser la contremarque pour obtenir une offre
+  + email (string) - correspond à l'email de la personne qui tente d'utiliser la contremarque pour obtenir une offre
   + offerId (optional, string) - identifiant de l'offre supposée correspondre à la réservation
 
 + Request (application/json)
-
-    + Headers
-       Authorization: Bearer xxxxx.yyyyy.zzzzz
 
     + Body
     
@@ -31,27 +26,15 @@ Vérifie la validité d'une contremarque et récupère les informations de la tr
               }
             ]
 
-+ Response 200 (application/json)
-
-    + Body
-
-            [
-              {
-                 "global": "OK",
-                 "email": "test@test.com",
-                 "userId": "Rosa",
-                 "offerId": "ABDE",
-                 "bookingId": "XYZ",
-              }
-            ]
++ Response 204 (application/json) dans le cas où le partenaire n'est pas enregistré
             
-+ Response 400 (application/json)
++ Response 404 (application/json)
 
     + Body
 
             [
               {
-                 "global": "Code contremarque invalide"
+                 "global": "Ce coupon n'a pas été trouvé"
               }
             ]
 
@@ -61,96 +44,6 @@ Vérifie la validité d'une contremarque et récupère les informations de la tr
 
             [
               {
-                 "global": "Contremarque déjà validée"
-              }
-            ]
-
-
-+ Response 400 (application/json)
-
-    + Body
-
-            [
-              {
-                 "global": "Contremarque expirée"
-              }
-            ]
-
-
-+ Response 400 (application/json)
-
-    + Body
-
-            [
-              {
-                 "global": "Vous ne disposez pas des droits pour accéder à cette contremarque"
-              }
-            ]
-
-##### Valider une contremarque [POST /bookings/validate]
-
-Valide une contremarque (et la transaction associée).
-
-Un code contremarque est valide 1 semaine pour les offres physiques, 30 minutes pour les offres numériques.
-
-+ Parameters
-
-  + email (optional, string) - obligatoire pour les offres numériques, correspond à l'email de la personne qui tente d'utiliser la contremarque pour obtenir une offre
-  + token (string) - le code de réservation
-  + offerId (optional, string) - identifiant de l'offre supposée correspondre à la réservation. Obligatoire pour les offres numériques.
-
-+ Request (application/json)
-
-    + Headers
-       Authorization: Bearer xxxxx.yyyyy.zzzzz
-
-    + Body
-       { 
-         "token": "AXB32J", 
-         "email": "test@test.com",
-         "offerId": "ABDE"
-       }
-
-+ Response 200 (application/json)
-
-+ Response 400 (application/json)
-
-    + Body
-
-            [
-              {
-                 "token": "Code contremarque invalide"
-              }
-            ]
-
-+ Response 400 (application/json)
-
-    + Body
-
-            [
-              {
-                 "global": "Contremarque déjà validée"
-              }
-            ]
-
-
-+ Response 400 (application/json)
-
-    + Body
-
-            [
-              {
-                 "global": "Contremarque expirée"
-              }
-            ]
-
-
-+ Response 400 (application/json)
-
-    + Body
-
-            [
-              {
-                 "global": "token et offerId ne correspondent pas"
+                 "email": "Vous devez préciser l\'email de l\'utilisateur quand vous n\'êtes pas connecté(e)"
               }
             ]


### PR DESCRIPTION
J'ai gardé la documentation uniquement pour ce qui n'est pas branché sur le front (donc ce qu'on renvoie quand pas d'identification) + j'ai spécifié les retours uniquement dans ce cas. La route GET est la seule concernée.